### PR TITLE
Fix build error and warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "json",
  "rouille",
  "rust-crypto",
+ "rustc-serialize",
  "serde",
  "serde-humantime",
  "serde_derive",
@@ -896,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ hex = "0.4.3"
 json = "0.12.4"
 
 structopt = "0.3.23"
+rustc-serialize = ">=0.3.25"

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ impl error::Error for ConfigError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             ConfigError::Parse(ref err) => Some(err),
             ConfigError::Io(ref err) => Some(err),

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,13 +26,6 @@ impl fmt::Display for ConfigError {
 }
 
 impl error::Error for ConfigError {
-    fn description(&self) -> &str {
-        match *self {
-            ConfigError::Parse(ref err) => err.description(),
-            ConfigError::Io(ref err) => err.description(),
-        }
-    }
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             ConfigError::Parse(ref err) => Some(err),

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
     let config = match config {
         Ok(config) => config,
         Err(err) => {
-            eprintln!("Failed to load config: {}", err.description());
+            eprintln!("Failed to load config: {}", err);
             return;
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,13 +9,11 @@ extern crate rouille;
 extern crate serde_derive;
 extern crate serde_humantime;
 extern crate serde_yaml;
-#[macro_use]
 extern crate structopt;
 
 
 use config::Config;
 use repo::Repo;
-use std::error::Error;
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, atomic::AtomicBool, atomic::Ordering};

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn main() {
             }
 
             Err(err) => {
-                eprintln!("[{}] Error while updating: {}", repo.name(), err.description());
+                eprintln!("[{}] Error while updating: {}", repo.name(), err);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ fn exec_hook(repo: Arc<Repo>) {
 
         let (stdout, stderr) = (child.stdout.take(), child.stderr.take());
 
-        crossbeam::scope(|scope| {
+        let c = crossbeam::scope(|scope| {
             if let Some(stdout) = stdout {
                 let stdout = BufReader::new(stdout);
                 scope.spawn(|_| {
@@ -145,6 +145,16 @@ fn exec_hook(repo: Arc<Repo>) {
                 });
             }
         });
+
+        if let Err(err) = c {
+            if let Some(string_err) = err.downcast_ref::<&str>() {
+                panic!("Failed to execute crossbeam: {}", string_err);
+            } else if let Some(string_err) = err.downcast_ref::<String>() {
+                panic!("Failed to execute crossbeam: {}", string_err);
+            } else {
+                panic!("Failed to execute crossbeam: unknown error");
+            }
+        }
 
         child.wait().expect("Failed to wait for script");
     }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -9,11 +9,13 @@ use std::sync::Mutex;
 use std::time::Instant;
 
 
+#[derive(Debug)]
 struct RepoState {
     last_checked: Option<Instant>,
     last_changed: Option<Instant>,
 }
 
+#[derive(Debug)]
 pub struct Repo {
     name: String,
     config: Config,

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -44,7 +44,7 @@ impl error::Error for UpdateError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             UpdateError::Git(ref err) => Some(err),
             UpdateError::Io(ref err) => Some(err),

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -39,13 +39,6 @@ impl fmt::Display for UpdateError {
 }
 
 impl error::Error for UpdateError {
-    fn description(&self) -> &str {
-        match *self {
-            UpdateError::Git(ref err) => err.description(),
-            UpdateError::Io(ref err) => err.description(),
-        }
-    }
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             UpdateError::Git(ref err) => Some(err),

--- a/src/webhook/github.rs
+++ b/src/webhook/github.rs
@@ -41,7 +41,7 @@ pub fn handle(repo: &Repo, config: &GitHubWebhook, request: &Request) -> Result<
     }
 
     // Parse the payload
-    let payload = json::parse(&body).map_err(|e| format!("Invalid payload: {}", e.description()))?;
+    let payload = json::parse(&body).map_err(|e| format!("Invalid payload: {}", e))?;
 
     // Check if push is for our remote branch
     println!("[{}] Got push event for '{}'", repo.name(), payload["ref"]);

--- a/src/webhook/github.rs
+++ b/src/webhook/github.rs
@@ -6,7 +6,6 @@ use hex;
 use json;
 use repo::Repo;
 use rouille::Request;
-use std::error::Error;
 use std::io::Read;
 
 

--- a/src/webhook/gitlab.rs
+++ b/src/webhook/gitlab.rs
@@ -30,7 +30,7 @@ pub fn handle(repo: &Repo, config: &GitLabWebhook, request: &Request) -> Result<
     }
 
     // Parse the payload
-    let payload = json::parse(&body).map_err(|e| format!("Invalid payload: {}", e.description()))?;
+    let payload = json::parse(&body).map_err(|e| format!("Invalid payload: {}", e))?;
 
     // Check if push is for our remote branch
     println!("[{}] Got push event for '{}'", repo.name(), payload["ref"]);

--- a/src/webhook/gitlab.rs
+++ b/src/webhook/gitlab.rs
@@ -2,7 +2,6 @@ use config::GitLabWebhook;
 use json;
 use repo::Repo;
 use rouille::Request;
-use std::error::Error;
 use std::io::Read;
 
 


### PR DESCRIPTION
* Ran cargo fix --bin "pullomatic" to satisfy "warning: trait objects without an explicit `dyn` are deprecated"
* Specified rustc-serialize version to remove error:

```
error[E0310]: the parameter type `T` may not live long enough
    --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustc-serialize-0.3.24/src/serialize.rs:1155:5
     |
1155 |     fn decode<D: Decoder>(d: &mut D) -> Result<Cow<'static, T>, D::Error...
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |     |
     |     the parameter type `T` must be valid for the static lifetime...
     |     ...so that the type `T` will meet its required lifetime bounds...
     |
note: ...that is required by this bound
    --> /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/alloc/src/borrow.rs:180:30
help: consider adding an explicit lifetime bound
```
* Fixed unhelpful message: `Failed to load config: description() is deprecated; use Display` and similar
* Reduced other compile-time warnings

tyia for reviewing!