### PR TITLE
Allow private key to be a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The following options are allowed in the configuration:
 | `credentials.username` | `str` | | The username to use if none is given by `remote_url` |
 | `credentials.password` | `str` | (✓) | The password used to authenticate (required for password authentication) |
 | `credentials.private_key` | `str` | (✓) | The private SSH key used to authenticate (required for SSH authentication) |
+| `credentials.private_key_path` | `bool` | | Specifies whether the `credentials.private_key` value represents a path to the key instead of the raw key itself |
 | `credentials.public_key` | `str` | | The public SSH key matching the private SSH key |
 | `credentials.passphrase` | `str` | | The passphrase used to unlock the private SSH KEY|
 | `interval.interval` | `str` | | The interval used to check the remote GIT repository for updates |

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,6 +55,7 @@ pub struct SSHCredentials {
 
     pub public_key: Option<String>,
     pub private_key: String,
+    pub private_key_path: bool,
 
     pub passphrase: Option<String>,
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -120,7 +120,7 @@ impl Repo {
                 if let Some(Credentials::SSH(ref ssh)) = self.config.credentials {
                     let private_key = if ssh.private_key_path {
                         let path = ssh.private_key.clone();
-                        let mut file = File::open(path).map_err(|_| git2::Error::from_str("Could not read credentials file"))?;
+                        let mut file = File::open(path).map_err(|_| git2::Error::from_str("Could not open credentials file"))?;
                         let mut contents = String::new();
                         file.read_to_string(&mut contents).map_err(|_| git2::Error::from_str("Could not read credentials file"))?;
                         contents


### PR DESCRIPTION
For security reasons it is preferable to keep the private key contained to just one location. This is especially true in the NixOS operating system, where configuration is specified in the "nix store" which is public. As such it is better if the (public) config can reference a private file not tracked in the store.

So, this PR adds support for having the private key be a file path instead of the raw value itself.